### PR TITLE
Sort index for recent docs listing

### DIFF
--- a/modules/data.xql
+++ b/modules/data.xql
@@ -319,10 +319,7 @@ declare function local:recent-docs($func, $count as xs:integer, $from as xs:inte
     let $docs := $coll//an:akomaNtoso/parent::node()
     let $docs-in-order := 
         for $doc in $docs
-            order by $doc//an:proprietary/gw:gawati/gw:dateTime[
-                @refersTo = '#dtModified'
-                ]/@datetime 
-            descending
+            order by sort:index("SIRecent", $doc)
         return $doc
     let $total-docs := count($docs-in-order)
     return

--- a/post-install.xql
+++ b/post-install.xql
@@ -1,5 +1,9 @@
 xquery version "3.0";
 
+declare namespace gw="http://gawati.org/ns/1.0";
+declare namespace an="http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+import module namespace config="http://gawati.org/xq/db/config" at "modules/config.xqm";
+
 import module namespace xdb="http://exist-db.org/xquery/xmldb";
 
 import module namespace util="http://exist-db.org/xquery/util";
@@ -21,6 +25,32 @@ declare function local:change-password() {
     let $ret := xdb:change-user($my-user, $pw, ($my-user))
     return $pw
 };
+
+(:~
+ : Convert the doc to sort into an atomic value of last modified time.
+ : @param $node The document to be sorted
+ :)
+declare function local:sort-callback($node as node()) {
+    $node//an:proprietary/gw:gawati/gw:dateTime[
+                @refersTo = '#dtModified'
+                ]/@datetime 
+};
+
+(:~
+ : Build a sort index for documents in the descending order of last modification
+ : @returns create-index-callback always returns an empty sequence
+ :)
+declare function local:build-sort-index() {
+    let $sc := config:storage-config("legaldocs")
+    let $coll := collection($sc("collection"))
+    let $node-set as document-node()+ := $coll//an:akomaNtoso/parent::node()
+    let $index-id as xs:string := 'SIRecent'
+    let $options := <options order="descending" empty='least'/>
+    let $sort-index := sort:create-index-callback($index-id, $node-set, local:sort-callback#1, $options)
+    return $sort-index
+};
+
+let $si := local:build-sort-index()
 
 let $pw := local:change-password()
 


### PR DESCRIPTION
Adds a sort-index on recent dates in post-install.xql. Possibly the same mechanism of sort-indexes can be applied to speed up all listings.